### PR TITLE
Fix nanosecond timestamp calculation to avoid precision loss

### DIFF
--- a/ublox_ubx_arrow_sink_node/include/ublox_ubx_arrow_sink_node/arrow_writer.hpp
+++ b/ublox_ubx_arrow_sink_node/include/ublox_ubx_arrow_sink_node/arrow_writer.hpp
@@ -237,7 +237,9 @@ namespace ublox::ubx {
     arrow::UInt32Builder v_acc_builder(pool);
 
     for (auto msg: hpposllh_msgs) {
-      int64_t ts_nano = msg->header.stamp.sec * 1e+9 + msg->header.stamp.nanosec;
+      int64_t ts_nano =
+        static_cast<int64_t>(msg->header.stamp.sec) * 1000000000LL +
+        msg->header.stamp.nanosec;
       // int64_t ts_micro = ts_nano / 1e+3;
       // ARROW_RETURN_NOT_OK(timestamp_builder.Append(ts_micro));
       ARROW_RETURN_NOT_OK(timestamp_builder.Append(ts_nano));


### PR DESCRIPTION
## Summary
- compute nanosecond timestamps using 64-bit integer arithmetic to avoid precision loss

## Testing
- `g++ -std=c++17 -c ublox_ubx_arrow_sink_node/src/arrow_sink_node.cpp` *(fails: rclcpp/rclcpp.hpp: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68965de75290832297e391d07228e7ce