### PR TITLE
Optimize move_msgs ownership transfers

### DIFF
--- a/ublox_ubx_arrow_sink_node/include/ublox_ubx_arrow_sink_node/arrow_writer.hpp
+++ b/ublox_ubx_arrow_sink_node/include/ublox_ubx_arrow_sink_node/arrow_writer.hpp
@@ -169,14 +169,12 @@ namespace ublox::ubx {
   std::vector<typename MessageT::SharedPtr> ArrowWriter<MessageT>::move_msgs(){
 
     // whatever is not the active queue, use as the msg source
-    // the queues should have been switched before append 
+    // the queues should have been switched before append
     if (active_msq_queue_ == 0) {
-      std::vector<typename MessageT::SharedPtr> msgs(msgs_1_);
-      msgs_1_.clear();
+      std::vector<typename MessageT::SharedPtr> msgs(std::move(msgs_1_));
       return msgs;
     } else {
-      std::vector<typename MessageT::SharedPtr> msgs(msgs_0_);
-      msgs_0_.clear();
+      std::vector<typename MessageT::SharedPtr> msgs(std::move(msgs_0_));
       return msgs;
     }
   }


### PR DESCRIPTION
## Summary
- use std::move when transferring queued messages in ArrowWriter
- avoid redundant clear calls after moving message queues

## Testing
- `colcon build --symlink-install` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68965f4033688322a3957912328c240d