### PR TITLE
Add ArrowWriter queue switch test

### DIFF
--- a/ublox_ubx_arrow_sink_node/CMakeLists.txt
+++ b/ublox_ubx_arrow_sink_node/CMakeLists.txt
@@ -59,6 +59,16 @@ if(BUILD_TESTING)
   # uncomment the line when this package is not in a git repo
   #set(ament_cmake_cpplint_FOUND TRUE)
   ament_lint_auto_find_test_dependencies()
+
+  find_package(ament_cmake_gtest REQUIRED)
+  ament_add_gtest(test_arrow_writer test/test_arrow_writer.cpp)
+  target_link_libraries(test_arrow_writer
+    arrow
+    parquet
+  )
+  ament_target_dependencies(test_arrow_writer
+    ublox_ubx_msgs
+  )
 endif()
 
 ament_package()

--- a/ublox_ubx_arrow_sink_node/package.xml
+++ b/ublox_ubx_arrow_sink_node/package.xml
@@ -12,6 +12,7 @@
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_gtest</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ublox_ubx_arrow_sink_node/test/test_arrow_writer.cpp
+++ b/ublox_ubx_arrow_sink_node/test/test_arrow_writer.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+#include "ublox_ubx_arrow_sink_node/arrow_writer.hpp"
+
+using ublox::ubx::ArrowWriter;
+using ublox_ubx_msgs::msg::UBXNavHPPosLLH;
+
+TEST(ArrowWriterTest, AppendRecordBatchClearsInactiveQueue)
+{
+  ArrowWriter<UBXNavHPPosLLH> writer{"", ""};
+
+  for (int i = 0; i < 3; ++i) {
+    auto msg = std::make_shared<UBXNavHPPosLLH>();
+    msg->header.stamp.sec = i;
+    msg->header.stamp.nanosec = i;
+    msg->header.frame_id = "map";
+    writer.add_msg(msg);
+  }
+
+  EXPECT_EQ(writer.switched_msgs_size(), 0u);
+
+  writer.switch_queues();
+  EXPECT_EQ(writer.switched_msgs_size(), 3u);
+
+  auto status = writer.append_record_batch();
+  ASSERT_TRUE(status.ok());
+
+  EXPECT_EQ(writer.switched_msgs_size(), 0u);
+  EXPECT_EQ(writer.record_batches_size(), 1u);
+  auto rows = writer.record_batches_rows();
+  ASSERT_EQ(rows.size(), 1u);
+  EXPECT_EQ(rows[0], 3u);
+}
+
+int main(int argc, char **argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- add GoogleTest validating ArrowWriter queue switching and record batch creation
- hook the new test into CMake build
- declare gtest dependency in package manifest

## Testing
- `colcon test --packages-select ublox_ubx_arrow_sink_node` *(fails: colcon: command not found)*
- `apt-get update` *(fails: repository access 403)*
- `cmake .. -DBUILD_TESTING=ON` *(fails: could not find ament_cmake)*

------
https://chatgpt.com/codex/tasks/task_e_68965f53ef508322a07b74bdc7c2282a