### PR TITLE
Fix namespace comment in arrow sink node

### DIFF
--- a/ublox_ubx_arrow_sink_node/src/arrow_sink_node.cpp
+++ b/ublox_ubx_arrow_sink_node/src/arrow_sink_node.cpp
@@ -126,6 +126,6 @@ private:
     }
   }
 };
-} // end namespace ublox_ubx_arrow
+} // namespace ublox::ubx
 
 RCLCPP_COMPONENTS_REGISTER_NODE(ublox::ubx::ArrowSinkNode)


### PR DESCRIPTION
## Summary
- fix closing comment for ublox::ubx namespace
- ensure arrow sink node source ends with newline

## Testing
- `colcon test` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68965f49d4fc83229ff4c5b477bbbe33